### PR TITLE
add startup_checklist.html

### DIFF
--- a/db.php
+++ b/db.php
@@ -44,6 +44,17 @@
         ");
     };
 
+    function db_create_startup_table(){
+        $result = db_query("
+            CREATE TABLE IF NOT EXISTS startup_checklist_filled (
+                id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+                username VARCHAR(100),
+                created TIMESTAMP DEFAULT NOW()
+            );
+        ");
+    };
+
+
     function db_quote($value) {
         $connection = db_connect();
         return "'" . mysqli_real_escape_string($connection,$value) . "'";
@@ -52,6 +63,11 @@
     function db_user_filled_checklist($username){
         db_query("INSERT INTO `park_checklist_filled` (`username`) VALUES (" . db_quote($username) . ")");
     };
+
+    function db_user_filled_startup_checklist($username){
+        db_query("INSERT INTO `startup_checklist_filled` (`username`) VALUES (" . db_quote($username) . ")");
+    };
+
 
 ?>
 

--- a/startup.php
+++ b/startup.php
@@ -1,0 +1,32 @@
+<!DOCTYPE HTML>
+<html>
+<?php require("head.html") ?>
+
+<body>
+<h1>FACT Startup Checklist</h1>
+Images not updated? Try refreshing the page a couple of times?<br>
+
+<?php
+    require_once("login.php");
+    if (!(login() == "")) {
+        exit("username or password not found.");
+    }
+
+    $image_path = "/home/factwww/Checklist/images/".date("Y")."/".date("m")."/";
+    if( !is_dir($image_path) ) {
+        mkdir($image_path, 0777, true);
+    }
+    require_once("tools.php");
+    require_once("compose_email_message.php");
+    require_once("getEmail.php");
+    require_once("db.php");
+    db_create_startup_table(); // creates the table if it does not exist;
+
+    load_lidcam_image();
+    load_IR_image();
+    require("startup_form.php");
+?>
+</body>
+</html>
+</body>
+</html>

--- a/startup_checklist.html
+++ b/startup_checklist.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <link rel="stylesheet" type="text/css" href="checkstyle.css" />
+<style>
+.error {color: #FF0000;}
+</style>
+</head>
+<body>
+
+<h1>FACT Startup Checklist</h1>
+<hr/>
+<br>
+
+<form method="post" action="startup.php"  enctype="multipart/form-data" >
+   <p>
+      User Name:    <input type='text' name='Uname' maxlength="50" /> <br>
+      Password:     <input type='password' name='Passwd' maxlength="50" /> <br>
+   </p>
+   <input type='submit' name='formpSubmit' value='Submit' />
+</form>
+</body>
+</html>

--- a/startup_doit.php
+++ b/startup_doit.php
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html>
+<?php require("head.html") ?>
+
+<body>
+
+<?php
+    require_once("login.php");
+    if (!(login() == "")) {
+        exit("username or password not found.");
+    }
+    require_once("tools.php");
+    require_once("db.php");
+    db_create_startup_table(); // creates the table if it does not exist;
+    db_user_filled_startup_checklist($_POST['Obsname']);
+?>
+
+</body>
+</html>
+</body>
+</html>

--- a/startup_form.php
+++ b/startup_form.php
@@ -46,6 +46,20 @@
           <td> <input type="checkbox" name="ticked_checks[]" value="swift"> </td>
         </tr>
 
+        <tr>
+          <td>
+            Do the FACT++ programs run
+            <br>
+            (green or yellow on this page)?
+            <br>
+            Are there at least 1.5TB diskspace? (last two rows)
+          </td>
+          <a href="https://fact-project.org/smartfact/index.html?#status">smartfact</a>
+          <td>
+          </td>
+          <td> <input type="checkbox" name="ticked_checks[]" value="servers_online"> </td>
+        </tr>
+
       </table>
 
    <h3> Submission: </h3> <?php echo submitter(); ?>

--- a/startup_form.php
+++ b/startup_form.php
@@ -40,8 +40,8 @@
 
         <tr>
           <td>Are there Swift observations?</td>
-          <a href="http://fact-project.org/dch/scheduling.php">scheduling.php</a>
           <td>
+          <a href="http://fact-project.org/dch/scheduling.php">scheduling.php</a>
           </td>
           <td> <input type="checkbox" name="ticked_checks[]" value="swift"> </td>
         </tr>

--- a/startup_form.php
+++ b/startup_form.php
@@ -19,6 +19,7 @@
           <td><img src="../cam/snap2.jpg" width="320" height="250" alt="cam picture" /></td>
           <td> <input type="checkbox" name="ticked_checks[]" value="parked"> </td>
         </tr>
+
         <tr>
           <td>Camera Looks okay?</td>
           <td>
@@ -28,6 +29,23 @@
           </td>
           <td> <input type="checkbox" name="ticked_checks[]" value="lid_closed"> </td>
         </tr>
+
+        <tr>
+          <td>Ist the schedule filled?</td>
+          <td>
+          <a href="https://www.fact-project.org/schedule/">Observation Scheduler</a>
+          </td>
+          <td> <input type="checkbox" name="ticked_checks[]" value="schedule_filled"> </td>
+        </tr>
+
+        <tr>
+          <td>Are there Swift observations?</td>
+          <a href="http://fact-project.org/dch/scheduling.php">scheduling.php</a>
+          <td>
+          </td>
+          <td> <input type="checkbox" name="ticked_checks[]" value="swift"> </td>
+        </tr>
+
       </table>
 
    <h3> Submission: </h3> <?php echo submitter(); ?>

--- a/startup_form.php
+++ b/startup_form.php
@@ -1,0 +1,35 @@
+<?php require_once("get_status_functions.php"); ?>
+
+<form method="post" action="startup_doit.php"  enctype="multipart/form-data" >
+      <input type='hidden' name='Obsname' maxlength="50" value="<?php echo $_POST['Uname']; ?>" />
+      <input type='hidden' name='Obsmail' maxlength="50" value="<?php echo getEmail(); ?>" />
+      <input type='hidden' name='Uname' maxlength="50" value="<?php echo $_POST['Uname']; ?>" />
+      <input type='hidden' name='Passwd' maxlength="50" value="<?php echo $_POST['Passwd']; ?>" />
+
+      <style>
+          table, td {
+              border: 1px solid grey;
+              border-collapse: collapse;
+          }
+      </style>
+
+      <table style="width:600">
+        <tr>
+          <td>No tourists?</td>
+          <td><img src="../cam/snap2.jpg" width="320" height="250" alt="cam picture" /></td>
+          <td> <input type="checkbox" name="ticked_checks[]" value="parked"> </td>
+        </tr>
+        <tr>
+          <td>Camera Looks okay?</td>
+          <td>
+            <img src="../cam/lidcam2.jpg" width="320" height="250" alt="lid picture" />
+            <br>
+            <?php echo lid_status(); ?>
+          </td>
+          <td> <input type="checkbox" name="ticked_checks[]" value="lid_closed"> </td>
+        </tr>
+      </table>
+
+   <h3> Submission: </h3> <?php echo submitter(); ?>
+   <input type='submit' name='formSubmit' value='Submit' />
+</form>

--- a/startup_form.php
+++ b/startup_form.php
@@ -54,8 +54,8 @@
             <br>
             Are there at least 1.5TB diskspace? (last two rows)
           </td>
-          <a href="https://fact-project.org/smartfact/index.html?#status">smartfact</a>
           <td>
+            <a href="https://fact-project.org/smartfact/index.html?#status">smartfact</a>
           </td>
           <td> <input type="checkbox" name="ticked_checks[]" value="servers_online"> </td>
         </tr>

--- a/startup_form.php
+++ b/startup_form.php
@@ -33,7 +33,7 @@
         <tr>
           <td>Ist the schedule filled?</td>
           <td>
-          <a href="https://www.fact-project.org/schedule/">Observation Scheduler</a>
+          <a target="_blank" href="https://www.fact-project.org/schedule/">Observation Scheduler</a>
           </td>
           <td> <input type="checkbox" name="ticked_checks[]" value="schedule_filled"> </td>
         </tr>
@@ -41,7 +41,7 @@
         <tr>
           <td>Are there Swift observations?</td>
           <td>
-          <a href="http://fact-project.org/dch/scheduling.php">scheduling.php</a>
+          <a target="_blank" href="http://fact-project.org/dch/scheduling.php">scheduling.php</a>
           </td>
           <td> <input type="checkbox" name="ticked_checks[]" value="swift"> </td>
         </tr>
@@ -55,7 +55,7 @@
             Are there at least 1.5TB diskspace? (last two rows)
           </td>
           <td>
-            <a href="https://fact-project.org/smartfact/index.html?#status">smartfact</a>
+            <a target="_blank" href="https://fact-project.org/smartfact/index.html?#status">smartfact</a>
           </td>
           <td> <input type="checkbox" name="ticked_checks[]" value="servers_online"> </td>
         </tr>


### PR DESCRIPTION
Also a startup_checklist was requested, it works like this.

Startup-person should check the webcams and start Main.js some time before startup, say 10 or 20 or 30 minutes .. whatever. If this is forgotten, shifthelper calls.

Things to be checked by the startup person include at the moment:

 * is the telescope still there (look at webcams)
 * is the schedule filled (otherwise main.js starts, but does nothing)
 * does the schedule need to be adjusted for common observation with swift.
 * -> start main.js and tick a box, saying that you really did it (maybe not needed, we have a check, which checks if main.js is actually running. we should simply let it start to check some time before the scheduled startup.)